### PR TITLE
Missing `Result.` module prefix in promise.re

### DIFF
--- a/src/native/promise.re
+++ b/src/native/promise.re
@@ -579,7 +579,7 @@ let allOkArray = promises => {
   let promiseCount = Array.length(promises);
 
   if (promiseCount == 0) {
-    resolved(Ok([||]));
+    resolved(Result.Ok([||]));
   }
   else {
     let resultValues = Array.make(promiseCount, None);


### PR DESCRIPTION
Fixes build on ocaml 4.02 (see https://github.com/ocaml/opam-repository/pull/17432)