### PR TITLE
add type exn so bucklescript warning goes away

### DIFF
--- a/src/js/promise.re
+++ b/src/js/promise.re
@@ -10,9 +10,9 @@ type never;
 type promise(+'a) = rejectable('a, never);
 type t(+'a) = promise('a);
 
+type exn;
 
-
-let onUnhandledException = ref(exn => {
+let onUnhandledException = ref((exn:exn) => {
   prerr_endline("Unhandled exception in promise callback:");
   Js.Console.error(exn);
 });

--- a/src/js/promise.rei
+++ b/src/js/promise.rei
@@ -15,7 +15,7 @@ type promise(+'a) = rejectable('a, never);  /* Internal; use Promise.t. */
 type t(+'a) = promise('a);
 
 
-
+type exn;
 /* Making promises. */
 let pending:
   unit =>


### PR DESCRIPTION
Not sure if this matters. But here it is. I had a project break for a second and add this opaque type deep in my node modules is what fixed it. No idea why.

![Screen Shot 2020-11-22 at 11 41 23 PM](https://user-images.githubusercontent.com/2370391/99919202-5696f500-2d1c-11eb-8ea3-9b391f6e482d.png)
